### PR TITLE
chore(.travis.yml): add 'travis_wait' to doxygen build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -293,7 +293,7 @@ after_script:
       DOXYGEN_DIR=doc/html;
       find $DOXYGEN_DIR -type f -name "*.md5" -exec rm {} ";";
       find $DOXYGEN_DIR -type f | split -l 100 - doxygen_files.txt.;
-      ls -1 doxygen_files.txt.* | parallel -u -j 10 ./script/dropbox_upload.py --destpath /Public --dropbox-token ${DROPBOX_KEY} --copylist {};
+      ls -1 doxygen_files.txt.* | travis_wait parallel -u -j 10 ./script/dropbox_upload.py --destpath /Public --dropbox-token ${DROPBOX_KEY} --copylist {};
   fi
 - if [[ $REPO == BLESSED && $UPLOAD ]]; then
       UPLOAD_DIR=bin;


### PR DESCRIPTION
"If you have a command that doesn't produce output for
more than 10 minutes, you can prefix it with travis_wait,
 a function that's exported by our build environment."

http://docs.travis-ci.com/user/build-timeouts/
