### PR TITLE
add vector and category

### DIFF
--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -70,36 +70,35 @@ definition epi  {A B : ob} (f : mor A B) : Prop := ∀⦃C⦄ {g h : mor B C}, g
 
 end
 
+
+using unit
+
 section
 
 parameters {obC obD : Type} {morC : obC → obC → Type} {morD : obD → obD → Type}
            (C : category obC morC) (D : category obD morD)
 
-instance C
-
-check @id
-check C
-check id2
-
-inductive functor :=
-functor_mk : Π (obF : obC → obD) (morF : Π{A B}, morC A B → morD (obF A) (obF B)),
-            (Π {A : obC}, morF (id2 A) = id2 (obF A)) →
---            (Π {A B C : obC} {f : morC A B} {g : morC B C}, morF (g ∘ f) = morF g ∘ morF f) →
-            functor
-
-end
-
-check @functor_mk
-check @functor_rec
-
-section
-using unit
-
 definition one : category unit (λa b, unit) :=
 cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
   (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
 
+instance one
+instance C
+
+-- check @id
+-- check C
+-- check id2
+
+-- inductive functor :=
+-- functor_mk : Π (obF : obC → obD) (morF : Π{A B}, morC A B → morD (obF A) (obF B)),
+--             (Π {A : obC}, morF (id2 A) = id2 (obF A)) →
+-- --            (Π {A B C : obC} {f : morC A B} {g : morC B C}, morF (g ∘ f) = morF g ∘ morF f) →
+--             functor
+
 end
+
+-- check @functor_mk
+-- check @functor_rec
 
 section
 --need extensionality

--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -13,20 +13,24 @@ cat_mk : Π (comp : Π⦃A B C : ob⦄, mor B C → mor A B → mor A C)
            (Π {A B : ob} {f : mor A B}, comp id f = f) →
             category ob mor
 
+class category
+
 namespace category
+
+precedence `∘` : 60
 
 section
 
 parameters {ob : Type} {mor : ob → ob → Type} {Cat : category ob mor}
 
-
 abbreviation compose := category_rec (λ comp id assoc idr idl, comp) Cat
-
-precedence `∘`:60
-infixr  ∘ := compose
-
 abbreviation id := category_rec (λ comp id assoc idr idl, id) Cat
 abbreviation ID (A : ob) := @id A
+
+end
+infixr `∘` := compose
+section
+parameters {ob : Type} {mor : ob → ob → Type} {Cat : category ob mor}
 
 theorem assoc : Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
             h ∘ (g ∘ f) = (h ∘ g) ∘ f :=
@@ -46,10 +50,15 @@ calc
   i = id ∘ i : symm id_left
   ... = id : H
 
-definition iso {A B : ob} (f : mor A B) : Type := Σ g, f ∘ g = id ∧ g ∘ f = id
+definition iso {A B : ob} (f : mor A B) : Type := including Cat, Σ g, f ∘ g = id ∧ g ∘ f = ID A
 definition inverse {A B : ob} (f : mor A B) (H : iso f) : mor B A := sigma.dpr1 H
 
 postfix `⁻¹` := inverse
+
+set_option pp.implicit true
+
+-- theorem foo {A B : ob} {f : mor A B} (H : iso f) : true :=
+-- including Cat, (λx (y : iso f),x) _ H
 
 theorem compose_inverse {A B : ob} {f : mor A B} (H : iso f) : f ∘ f⁻¹ H = id :=
 and_elim_left (sigma.dpr2 H)
@@ -58,49 +67,58 @@ theorem inverse_compose {A B : ob} {f : mor A B} (H : iso f) : f⁻¹ H ∘ f = 
 and_elim_right (sigma.dpr2 H)
 
 theorem inverse_unique {A B : ob} {f : mor A B} (H H' : iso f) : f⁻¹ H = f⁻¹ H' :=
-calc
-  f⁻¹ H = f⁻¹ H ∘ id : symm id_right
-    ... = f⁻¹ H ∘ f ∘ f⁻¹ H' : {symm (compose_inverse H')}
-    ... = (f⁻¹ H ∘ f) ∘ f⁻¹ H' : assoc
-    ... = id ∘ f⁻¹ H' : {inverse_compose H}
-    ... = f⁻¹ H' : id_left
+sorry
+ -- calc
+ --  inverse f H = f⁻¹ H ∘ id : symm id_right
+ --    ... = f⁻¹ H ∘ f ∘ f⁻¹ H' : {symm (compose_inverse H')}
+ --    ... = (f⁻¹ H ∘ f) ∘ f⁻¹ H' : assoc
+ --    ... = id ∘ f⁻¹ H' : {inverse_compose H}
+ --    ... = f⁻¹ H' : id_left
 
-definition mono {A B : ob} (f : mor A B) : Prop := ∀⦃C⦄ {g h : mor C A}, f ∘ g = f ∘ h → g = h
-definition epi  {A B : ob} (f : mor A B) : Prop := ∀⦃C⦄ {g h : mor B C}, g ∘ f = h ∘ f → g = h
+definition mono {A B : ob} (f : mor A B) : Prop :=
+including Cat, ∀⦃C⦄ {g h : mor C A}, f ∘ g = f ∘ h → g = h
+definition epi  {A B : ob} (f : mor A B) : Prop :=
+including Cat, ∀⦃C⦄ {g h : mor B C}, g ∘ f = h ∘ f → g = h
 
 end
 
-
-using unit
-
-definition one [instance] : category unit (λa b, unit) :=
-cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
-  (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
-
-check compose star star
 
 section
 
 parameters {obC obD : Type} {morC : obC → obC → Type} {morD : obD → obD → Type}
  (C : category obC morC)
-parameter ( D : category obD morD )
+parameter D : category obD morD
 
-instance C
+definition tst (a b c : obC) (m1 : morC a b) (m2 : morC b c) :=
+(λx y, x) (compose m2 m1) (including C, false)
 
--- check @id
--- check C
--- check id2
+definition tst2 (C : category obC morC) (a b c : obC) (m1 : morC a b) (m2 : morC b c) :=
+compose m2 m1
 
--- inductive functor :=
--- functor_mk : Π (obF : obC → obD) (morF : Π{A B}, morC A B → morD (obF A) (obF B)),
---             (Π {A : obC}, morF (id2 A) = id2 (obF A)) →
--- --            (Π {A B C : obC} {f : morC A B} {g : morC B C}, morF (g ∘ f) = morF g ∘ morF f) →
+parameter a : obC
+parameter f : morC a a
+check including C, (f ∘ f)
+
+-- inductive foo : Type :=
+-- mk : including C, foo
+
+-- inductive functor : Type :=
+-- functor_mk : including C D,
+--             Π (obF : obC → obD) (morF : Π{A B}, morC A B → morD (obF A) (obF B)),
+--            (Π {A : obC}, morF (ID A) = ID (obF A)) →
+--            (Π {A B C : obC} {f : morC A B} {g : morC B C}, morF (g ∘ f) = morF g ∘ morF f) →
 --             functor
 
 end
 
--- check @functor_mk
--- check @functor_rec
+section
+using unit
+definition one [instance] : category unit (λa b, unit) :=
+cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
+  (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
+using unit
+
+end
 
 section
 --need extensionality

--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -5,7 +5,7 @@ import data.unit data.sigma data.prod
 import struc.function
 
 inductive category (ob : Type) (mor : ob → ob → Type) : Type :=
-cat_mk : Π (comp : Π{A B C : ob}, mor B C → mor A B → mor A C)
+cat_mk : Π (comp : Π⦃A B C : ob⦄, mor B C → mor A B → mor A C)
            (id : Π {A : ob}, mor A A),
             (Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
             comp h (comp g f) = comp (comp h g) f) →
@@ -26,7 +26,7 @@ precedence `∘`:60
 infixr  ∘ := compose
 
 abbreviation id := category_rec (λ comp id assoc idr idl, id) Cat
-abbreviation id2 (A : ob) := @id A
+abbreviation ID (A : ob) := @id A
 
 theorem assoc : Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
             h ∘ (g ∘ f) = (h ∘ g) ∘ f :=
@@ -73,16 +73,18 @@ end
 
 using unit
 
-section
-
-parameters {obC obD : Type} {morC : obC → obC → Type} {morD : obD → obD → Type}
-           (C : category obC morC) (D : category obD morD)
-
-definition one : category unit (λa b, unit) :=
+definition one [instance] : category unit (λa b, unit) :=
 cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
   (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
 
-instance one
+check compose star star
+
+section
+
+parameters {obC obD : Type} {morC : obC → obC → Type} {morD : obD → obD → Type}
+ (C : category obC morC)
+parameter ( D : category obD morD )
+
 instance C
 
 -- check @id
@@ -107,5 +109,6 @@ cat_mk (λ a b c f g, function.compose f g) (λ a, function.id) (λ a b c d f g 
   (λ a b f, sorry) (λ a b f, sorry)
 
 end
+
 
 end category

--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -5,7 +5,7 @@ import data.unit data.sigma data.prod
 import struc.function
 
 inductive category (ob : Type) (mor : ob → ob → Type) : Type :=
-cat_mk : Π (comp : Π⦃A B C : ob⦄, mor B C → mor A B → mor A C)
+mk : Π (comp : Π⦃A B C : ob⦄, mor B C → mor A B → mor A C)
            (id : Π {A : ob}, mor A A),
             (Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
             comp h (comp g f) = comp (comp h g) f) →
@@ -23,8 +23,8 @@ section
 
 parameters {ob : Type} {mor : ob → ob → Type} {Cat : category ob mor}
 
-abbreviation compose := category_rec (λ comp id assoc idr idl, comp) Cat
-abbreviation id := category_rec (λ comp id assoc idr idl, id) Cat
+abbreviation compose := category.rec (λ comp id assoc idr idl, comp) Cat
+abbreviation id := category.rec (λ comp id assoc idr idl, id) Cat
 abbreviation ID (A : ob) := @id A
 
 end
@@ -34,20 +34,22 @@ parameters {ob : Type} {mor : ob → ob → Type} {Cat : category ob mor}
 
 theorem assoc : Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
             h ∘ (g ∘ f) = (h ∘ g) ∘ f :=
-category_rec (λ comp id assoc idr idl, assoc) Cat
+category.rec (λ comp id assoc idr idl, assoc) Cat
+
 theorem id_right : Π {A B : ob} {f : mor A B}, f ∘ id = f :=
-category_rec (λ comp id assoc idr idl, idr) Cat
+category.rec (λ comp id assoc idr idl, idr) Cat
 theorem id_left  : Π {A B : ob} {f : mor A B}, id ∘ f = f :=
-category_rec (λ comp id assoc idr idl, idl) Cat
+category.rec (λ comp id assoc idr idl, idl) Cat
+
 
 theorem left_id_unique {A : ob} (i : mor A A) (H : Π{B} {f : mor B A}, i ∘ f = f) : i = id :=
 calc
-  i = i ∘ id : symm id_right
+  i = i ∘ id : eq.symm id_right
   ... = id : H
 
 theorem right_id_unique {A : ob} (i : mor A A) (H : Π{B} {f : mor A B}, f ∘ i = f) : i = id :=
 calc
-  i = id ∘ i : symm id_left
+  i = id ∘ i : eq.symm id_left
   ... = id : H
 
 definition has_left_inverse {A B : ob} (f : mor A B) : Type :=
@@ -78,19 +80,19 @@ set_option pp.implicit true
 -- including Cat, (λx (y : iso f),x) _ H
 
 theorem compose_inverse {A B : ob} {f : mor A B} (H : iso f) : f ∘ f⁻¹ H = id :=
-and_elim_left (sigma.dpr2 H)
+and.elim_left (sigma.dpr2 H)
 
 theorem inverse_compose {A B : ob} {f : mor A B} (H : iso f) : f⁻¹ H ∘ f = id :=
-and_elim_right (sigma.dpr2 H)
+and.elim_right (sigma.dpr2 H)
 
 theorem inverse_unique {A B : ob} {f : mor A B} (H H' : iso f) : f⁻¹ H = f⁻¹ H' :=
 sorry
  -- calc
- --  inverse f H = f⁻¹ H ∘ id : symm id_right
+ --  inverse f H = f⁻¹ H ∘ id : symm id.right
  --    ... = f⁻¹ H ∘ f ∘ f⁻¹ H' : {symm (compose_inverse H')}
  --    ... = (f⁻¹ H ∘ f) ∘ f⁻¹ H' : assoc
  --    ... = id ∘ f⁻¹ H' : {inverse_compose H}
- --    ... = f⁻¹ H' : id_left
+ --    ... = f⁻¹ H' : id.left
 
 definition mono {A B : ob} (f : mor A B) : Prop :=
 including Cat, ∀⦃C⦄ {g h : mor C A}, f ∘ g = f ∘ h → g = h
@@ -119,7 +121,7 @@ check including C, (f ∘ f)
 -- mk : including C, foo
 
 -- inductive functor : Type :=
--- functor_mk : including C D,
+-- functor.mk : including C D,
 --             Π (obF : obC → obD) (morF : Π{A B}, morC A B → morD (obF A) (obF B)),
 --            (Π {A : obC}, morF (ID A) = ID (obF A)) →
 --            (Π {A B C : obC} {f : morC A B} {g : morC B C}, morF (g ∘ f) = morF g ∘ morF f) →
@@ -128,10 +130,10 @@ check including C, (f ∘ f)
 end
 
 section
--- using unit
--- definition one [instance] : category unit (λa b, unit) :=
--- cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
---   (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
+open unit
+definition one [instance] : category unit (λa b, unit) :=
+category.mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit.equal _ _)
+  (λ a b f, unit.equal _ _) (λ a b f, unit.equal _ _)
 
 
 end
@@ -139,7 +141,7 @@ end
 section
 --need extensionality
 definition type_cat : category Type (λA B, A → B) :=
-cat_mk (λ a b c f g, function.compose f g) (λ a, function.id) (λ a b c d f g h, sorry)
+mk (λ a b c f g, function.compose f g) (λ a, function.id) (λ a b c d f g h, sorry)
   (λ a b f, sorry) (λ a b f, sorry)
 
 end

--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -50,8 +50,25 @@ calc
   i = id ∘ i : symm id_left
   ... = id : H
 
-definition iso {A B : ob} (f : mor A B) : Type := including Cat, Σ g, f ∘ g = id ∧ g ∘ f = ID A
+definition has_left_inverse {A B : ob} (f : mor A B) : Type :=
+including Cat, Σ g, g ∘ f = id
+definition left_inverse {A B : ob} (f : mor A B) (H : has_left_inverse f) : mor B A :=
+sigma.dpr1 H
+definition has_right_inverse {A B : ob} (f : mor A B) : Type :=
+including Cat, Σ g, f ∘ g = id
+definition right_inverse {A B : ob} (f : mor A B) (H : has_right_inverse f) : mor B A :=
+sigma.dpr1 H
+definition iso {A B : ob} (f : mor A B) : Type := including Cat, Σ g, f ∘ g = id ∧ g ∘ f = id
 definition inverse {A B : ob} (f : mor A B) (H : iso f) : mor B A := sigma.dpr1 H
+
+theorem iso_imp_left_inverse {A B : ob} (f : mor A B) (H : iso f) : has_left_inverse f :=
+sorry
+theorem iso_imp_right_inverse {A B : ob} (f : mor A B) (H : iso f) : has_left_inverse f :=
+sorry
+theorem left_right_inverse_imp_iso {A B : ob} (f : mor A B)
+    (Hl : has_left_inverse f) (Hr : has_right_inverse f) : iso f :=
+sorry
+
 
 postfix `⁻¹` := inverse
 
@@ -111,11 +128,11 @@ check including C, (f ∘ f)
 end
 
 section
-using unit
-definition one [instance] : category unit (λa b, unit) :=
-cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
-  (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
-using unit
+-- using unit
+-- definition one [instance] : category unit (λa b, unit) :=
+-- cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
+--   (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
+
 
 end
 

--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -1,0 +1,112 @@
+-- category
+
+import logic.core.eq logic.core.connectives
+import data.unit data.sigma data.prod
+import struc.function
+
+inductive category (ob : Type) (mor : ob → ob → Type) : Type :=
+cat_mk : Π (comp : Π{A B C : ob}, mor B C → mor A B → mor A C)
+           (id : Π {A : ob}, mor A A),
+            (Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
+            comp h (comp g f) = comp (comp h g) f) →
+           (Π {A B : ob} {f : mor A B}, comp f id = f) →
+           (Π {A B : ob} {f : mor A B}, comp id f = f) →
+            category ob mor
+
+namespace category
+
+section
+
+parameters {ob : Type} {mor : ob → ob → Type} {Cat : category ob mor}
+
+
+abbreviation compose := category_rec (λ comp id assoc idr idl, comp) Cat
+
+precedence `∘`:60
+infixr  ∘ := compose
+
+abbreviation id := category_rec (λ comp id assoc idr idl, id) Cat
+abbreviation id2 (A : ob) := @id A
+
+theorem assoc : Π {A B C D : ob} {f : mor A B} {g : mor B C} {h : mor C D},
+            h ∘ (g ∘ f) = (h ∘ g) ∘ f :=
+category_rec (λ comp id assoc idr idl, assoc) Cat
+theorem id_right : Π {A B : ob} {f : mor A B}, f ∘ id = f :=
+category_rec (λ comp id assoc idr idl, idr) Cat
+theorem id_left  : Π {A B : ob} {f : mor A B}, id ∘ f = f :=
+category_rec (λ comp id assoc idr idl, idl) Cat
+
+theorem left_id_unique {A : ob} (i : mor A A) (H : Π{B} {f : mor B A}, i ∘ f = f) : i = id :=
+calc
+  i = i ∘ id : symm id_right
+  ... = id : H
+
+theorem right_id_unique {A : ob} (i : mor A A) (H : Π{B} {f : mor A B}, f ∘ i = f) : i = id :=
+calc
+  i = id ∘ i : symm id_left
+  ... = id : H
+
+definition iso {A B : ob} (f : mor A B) : Type := Σ g, f ∘ g = id ∧ g ∘ f = id
+definition inverse {A B : ob} (f : mor A B) (H : iso f) : mor B A := sigma.dpr1 H
+
+postfix `⁻¹` := inverse
+
+theorem compose_inverse {A B : ob} {f : mor A B} (H : iso f) : f ∘ f⁻¹ H = id :=
+and_elim_left (sigma.dpr2 H)
+
+theorem inverse_compose {A B : ob} {f : mor A B} (H : iso f) : f⁻¹ H ∘ f = id :=
+and_elim_right (sigma.dpr2 H)
+
+theorem inverse_unique {A B : ob} {f : mor A B} (H H' : iso f) : f⁻¹ H = f⁻¹ H' :=
+calc
+  f⁻¹ H = f⁻¹ H ∘ id : symm id_right
+    ... = f⁻¹ H ∘ f ∘ f⁻¹ H' : {symm (compose_inverse H')}
+    ... = (f⁻¹ H ∘ f) ∘ f⁻¹ H' : assoc
+    ... = id ∘ f⁻¹ H' : {inverse_compose H}
+    ... = f⁻¹ H' : id_left
+
+definition mono {A B : ob} (f : mor A B) : Prop := ∀⦃C⦄ {g h : mor C A}, f ∘ g = f ∘ h → g = h
+definition epi  {A B : ob} (f : mor A B) : Prop := ∀⦃C⦄ {g h : mor B C}, g ∘ f = h ∘ f → g = h
+
+end
+
+section
+
+parameters {obC obD : Type} {morC : obC → obC → Type} {morD : obD → obD → Type}
+           (C : category obC morC) (D : category obD morD)
+
+instance C
+
+check @id
+check C
+check id2
+
+inductive functor :=
+functor_mk : Π (obF : obC → obD) (morF : Π{A B}, morC A B → morD (obF A) (obF B)),
+            (Π {A : obC}, morF (id2 A) = id2 (obF A)) →
+--            (Π {A B C : obC} {f : morC A B} {g : morC B C}, morF (g ∘ f) = morF g ∘ morF f) →
+            functor
+
+end
+
+check @functor_mk
+check @functor_rec
+
+section
+using unit
+
+definition one : category unit (λa b, unit) :=
+cat_mk (λ a b c f g, star) (λ a, star) (λ a b c d f g h, unit_eq _ _)
+  (λ a b f, unit_eq _ _) (λ a b f, unit_eq _ _)
+
+end
+
+section
+--need extensionality
+definition type_cat : category Type (λA B, A → B) :=
+cat_mk (λ a b c f g, function.compose f g) (λ a, function.id) (λ a b c d f g h, sorry)
+  (λ a b f, sorry) (λ a b f, sorry)
+
+end
+
+end category

--- a/library/data/category.lean
+++ b/library/data/category.lean
@@ -82,7 +82,6 @@ including Cat, ∀⦃C⦄ {g h : mor B C}, g ∘ f = h ∘ f → g = h
 
 end
 
-
 section
 
 parameters {obC obD : Type} {morC : obC → obC → Type} {morD : obD → obD → Type}

--- a/library/data/empty.lean
+++ b/library/data/empty.lean
@@ -14,11 +14,12 @@ inductive empty : Type
 namespace empty
   theorem elim [protected] (A : Type) (H : empty) : A :=
   rec (λe, A) H
-
 end empty
 
-theorem false.to_empty (H : false) : empty :=
+namespace false
+theorem to_empty (H : false) : empty :=
 cast (false_elim H) true
 
-theorem false.rec_type (A : Type) (H : false) : A :=
-empty_rec (λx,A) (false_to_empty H)
+theorem rec_type (A : Type) (H : false) : A :=
+empty.rec (λx,A) (to_empty H)
+end false

--- a/library/data/empty.lean
+++ b/library/data/empty.lean
@@ -7,9 +7,18 @@
 -- Empty type
 -- ----------
 
+import logic.core.cast
+
 inductive empty : Type
 
 namespace empty
   theorem elim [protected] (A : Type) (H : empty) : A :=
   rec (λe, A) H
+
 end empty
+
+theorem false.to_empty (H : false) : empty :=
+cast (false_elim H) true
+
+theorem false.rec_type (A : Type) (H : false) : A :=
+empty_rec (λx,A) (false_to_empty H)

--- a/library/data/vector.lean
+++ b/library/data/vector.lean
@@ -9,7 +9,7 @@ cons : T → ∀{n}, vec T n → vec T (succ n)
 
 infix `::` := cons --at what level?
 
-section
+section sc_vec
 
 variable {T : Type}
 
@@ -95,7 +95,7 @@ sorry
 theorem vec0_eq_nil (v : vec T 0) : v = nil :=
 case_zero v rfl
 
-definition length {n : ℕ} (v : vec T n) := n
+
 
 -- Concat
 -- ------
@@ -130,12 +130,12 @@ theorem cons_concat {n m : ℕ} (x : T) (v : vec T n) (w : vec T m)
 --         ... = concat (cons x l) (concat t u) : refl _)
 
 
--- -- Length
--- -- ------
+-- Length
+-- ------
 
--- definition length : list T → ℕ := list_rec 0 (fun x l m, succ m)
+definition length {n : ℕ} (v : vec T n) := n
 
--- theorem length_nil : length (@nil T) = 0 := rfl
+theorem length_nil : length (@nil T) = 0 := rfl
 
 -- theorem length_cons (x : T) (t : list T) : length (x :: t) = succ (length t) := rfl
 

--- a/library/data/vector.lean
+++ b/library/data/vector.lean
@@ -1,0 +1,347 @@
+import data.nat.basic data.empty
+using nat eq_ops num
+
+namespace vec
+
+inductive vec (T : Type) : ℕ → Type :=
+nil {} : vec T 0,
+cons : T → ∀{n}, vec T n → vec T (succ n)
+
+infix `::` := cons --at what level?
+
+section
+
+variable {T : Type}
+
+notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
+
+theorem rec_on {C : ∀ (n : ℕ), vec T n → Type} {n : ℕ} (v : vec T n) (Hnil : C 0 nil)
+  (Hcons : ∀(x : T) {n : ℕ} (w : vec T n), C n w → C (succ n) (cons x w)) : C n v :=
+vec_rec Hnil Hcons v
+
+theorem induction_on {C : ∀ (n : ℕ), vec T n → Prop} {n : ℕ} (v : vec T n) (Hnil : C 0 nil)
+  (Hcons : ∀(x : T) {n : ℕ} (w : vec T n), C n w → C (succ n) (cons x w)) : C n v :=
+rec_on v Hnil Hcons
+
+theorem case_on {C : ∀ (n : ℕ), vec T n → Type} {n : ℕ} (v : vec T n) (Hnil : C 0 nil)
+  (Hcons : ∀(x : T) {n : ℕ} (w : vec T n), C (succ n) (cons x w)) : C n v :=
+rec_on v Hnil (take x n v IH, Hcons x v)
+
+theorem case_zero_lem [private] {C : vec T 0 → Type} {n : ℕ} (v : vec T n) (Hnil : C nil) :
+  ∀ H : n = 0, C (cast (congr_arg (vec T) H) v) :=
+rec_on v (take H : 0 = 0, (eq_rec Hnil (cast_eq _ nil⁻¹)))
+ (take (x : T) (n : ℕ) (w : vec T n) IH (H : succ n = 0),
+    false_rec_type _ (absurd H succ_ne_zero))
+
+theorem case_zero {C : vec T 0 → Type} (v : vec T 0) (Hnil : C nil) : C v :=
+eq_rec (case_zero_lem v Hnil (refl 0)) (cast_eq _ v)
+
+
+-- Definition rectS {A} (P:forall {n}, t A (S n) -> Type)
+--  (bas: forall a: A, P (a :: []))
+--  (rect: forall a {n} (v: t A (S n)), P v -> P (a :: v)) :=
+--  fix rectS_fix {n} (v: t A (S n)) : P v :=
+--  match v with
+--  |nil => fun devil => False_rect (@ID) devil
+--  |cons a 0 v =>
+--    match v as vnn in t _ nn
+--        return
+--          match nn,vnn with
+--          |0,vm => P (a :: vm)
+--          |S _,_ => _
+--          end
+--      with
+--      |nil => bas a
+--      |_ :: _ => fun devil => False_rect (@ID) devil
+--      end
+--  |cons a (S nn') v => rect a v (rectS_fix v)
+--  end.
+
+theorem rec_nonempty_lem [private] {C : Π{n}, vec T (succ n) → Type} {n : ℕ} (v : vec T n)
+    (Hone : Πa, C [a]) (Hcons : Πa {n} (v : vec T (succ n)), C v → C (a :: v))
+    : ∀{m} (H : n = succ m), C (cast (congr_arg (vec T) H) v) :=
+case_on v (take m (H : 0 = succ m), false_rec_type _ (absurd (H⁻¹) succ_ne_zero))
+  (take x n v m H,
+    have H2 : C (x::v), from
+      sorry,
+      -- rec_on v
+      --   (Hone x)
+      --   (take y n w IH, Hcons x (y::w)),
+    show C (cast (congr_arg (vec T) H) (x::v)), from
+      sorry
+)
+
+theorem rec_nonempty {C : Π{n}, vec T (succ n) → Type} {n : ℕ} (v : vec T (succ n))
+    (Hone : Πa, C [a]) (Hcons : Πa {n} (v : vec T (succ n)), C v → C (a :: v)) : C v :=
+sorry
+
+
+-- Definition caseS {A} (P : forall {n}, t A (S n) -> Type)
+--   (H : forall h {n} t, @P n (h :: t)) {n} (v: t A (S n)) : P v :=
+-- match v as v' in t _ m return match m, v' with |0, _ => False -> True |S _, v0 => P v' end with
+--   |[] => fun devil => False_rect _ devil
+--   |h :: t => H h t
+-- end.
+
+theorem case_succ_lem [private] {C : Π{n}, vec T (succ n) → Type} {n : ℕ} (v : vec T n)
+    (H : Πa {n} (v : vec T n), C (a :: v))
+    : ∀{m} (H : n = succ m), C (cast (congr_arg (vec T) H) v) :=
+sorry
+
+theorem case_succ {C : Π{n}, vec T (succ n) → Type} {n : ℕ} (v : vec T (succ n))
+    (H : Πa {n} (v : vec T n), C (a :: v)) : C v :=
+sorry
+
+theorem vec0_eq_nil (v : vec T 0) : v = nil :=
+case_zero v rfl
+
+definition length {n : ℕ} (v : vec T n) := n
+
+-- Concat
+-- ------
+
+abbreviation cast_subst {A : Type} {P : A → Type} {a a' : A} (H : a = a') (B : P a) : P a' :=
+cast (congr_arg P H) B
+
+definition concat {n m : ℕ} (v : vec T n) (w : vec T m) : vec T (n + m) :=
+vec_rec (cast_subst (add_zero_left⁻¹) w) (λx n w' u, cast_subst (add_succ_left⁻¹) (x::u)) v
+
+infixl `++` : 65 := concat
+
+theorem nil_concat {n : ℕ} (v : vec T n) : nil ++ v = cast_subst (add_zero_left⁻¹) v := rfl
+
+theorem cons_concat {n m : ℕ} (x : T) (v : vec T n) (w : vec T m)
+    : (x :: v) ++ w = cast_subst (add_succ_left⁻¹) (x::(v++w)) := rfl
+
+-- theorem cons_concat (x : T) (s t : list T) : (x :: s) ++ t = x :: (s ++ t) := refl _
+
+-- theorem concat_nil (t : list T) : t ++ nil = t :=
+-- list_induction_on t (refl _)
+--   (take (x : T) (l : list T) (H : concat l nil = l),
+--     show concat (cons x l) nil = cons x l, from H ▸ refl _)
+
+-- theorem concat_assoc (s t u : list T) : s ++ t ++ u = s ++ (t ++ u) :=
+-- list_induction_on s (refl _)
+--   (take x l,
+--     assume H : concat (concat l t) u = concat l (concat t u),
+--     calc
+--       concat (concat (cons x l) t) u = cons x (concat (concat l t) u) : refl _
+--         ... = cons x (concat l (concat t u)) : { H }
+--         ... = concat (cons x l) (concat t u) : refl _)
+
+
+-- -- Length
+-- -- ------
+
+-- definition length : list T → ℕ := list_rec 0 (fun x l m, succ m)
+
+-- theorem length_nil : length (@nil T) = 0 := rfl
+
+-- theorem length_cons (x : T) (t : list T) : length (x :: t) = succ (length t) := rfl
+
+-- theorem length_concat (s t : list T) : length (s ++ t) = length s + length t :=
+-- list_induction_on s
+--   (calc
+--     length (concat nil t) = length t   : rfl
+--       ... = zero + length t            : {add_zero_left⁻¹}
+--       ... = length (@nil T) + length t : rfl)
+--   (take x s,
+--     assume H : length (concat s t) = length s + length t,
+--     calc
+--       length (concat (cons x s) t ) = succ (length (concat s t))  : rfl
+--         ... = succ (length s + length t)   : { H }
+--         ... = succ (length s) + length t   : {add_succ_left⁻¹}
+--         ... = length (cons x s) + length t : rfl)
+
+-- -- add_rewrite length_nil length_cons
+
+
+-- -- Append
+-- -- ------
+
+-- definition append (x : T) : list T → list T := list_rec [x] (fun y l l', y :: l')
+
+-- theorem append_nil (x : T) : append x nil = [x] := refl _
+
+-- theorem append_cons (x : T) (y : T) (l : list T) : append x (y :: l)  = y :: (append x l) := refl _
+
+-- theorem append_eq_concat  (x : T) (l : list T) : append x l = l ++ [x] := refl _
+
+-- -- add_rewrite append_nil append_cons
+
+
+-- -- Reverse
+-- -- -------
+
+-- definition reverse : list T → list T := list_rec nil (fun x l r, r ++ [x])
+
+-- theorem reverse_nil : reverse (@nil T) = nil := refl _
+
+-- theorem reverse_cons (x : T) (l : list T) : reverse (x :: l) = append x (reverse l) := refl _
+
+-- theorem reverse_singleton (x : T) : reverse [x] = [x] := refl _
+
+-- theorem reverse_concat (s t : list T) : reverse (s ++ t) = (reverse t) ++ (reverse s) :=
+-- list_induction_on s (symm (concat_nil _))
+--   (take x s,
+--     assume IH : reverse (s ++ t) = concat (reverse t) (reverse s),
+--     calc
+--       reverse ((x :: s) ++ t) = reverse (s ++ t) ++ [x] : refl _
+--         ... = reverse t ++ reverse s ++ [x] : {IH}
+--         ... = reverse t ++ (reverse s ++ [x]) : concat_assoc _ _ _
+--         ... = reverse t ++ (reverse (x :: s)) : refl _)
+
+-- theorem reverse_reverse (l : list T) : reverse (reverse l) = l :=
+-- list_induction_on l (refl _)
+--   (take x l',
+--     assume H: reverse (reverse l') = l',
+--     show reverse (reverse (x :: l')) = x :: l', from
+--       calc
+--         reverse (reverse (x :: l')) = reverse (reverse l' ++ [x]) : refl _
+--           ... = reverse [x] ++ reverse (reverse l') : reverse_concat _ _
+--           ... = [x] ++ l' : { H }
+--           ... = x :: l' : refl _)
+
+-- theorem append_eq_reverse_cons  (x : T) (l : list T) : append x l = reverse (x :: reverse l) :=
+-- list_induction_on l (refl _)
+--   (take y l',
+--     assume H : append x l' = reverse (x :: reverse l'),
+--     calc
+--       append x (y :: l') = (y :: l') ++ [ x ] : append_eq_concat _ _
+--         ... = concat (reverse (reverse (y :: l'))) [ x ] : {symm (reverse_reverse _)}
+--         ... = reverse (x :: (reverse (y :: l'))) : refl _)
+
+
+-- -- Head and tail
+-- -- -------------
+
+-- definition head (x0 : T) : list T → T := list_rec x0 (fun x l h, x)
+
+-- theorem head_nil (x0 : T) : head x0 (@nil T) = x0 := refl _
+
+-- theorem head_cons (x : T) (x0 : T) (t : list T) : head x0 (x :: t) = x := refl _
+
+-- theorem head_concat (s t : list T) (x0 : T) : s ≠ nil → (head x0 (s ++ t) = head x0 s) :=
+-- list_cases_on s
+--   (take H : nil ≠ nil, absurd (refl nil) H)
+--   (take x s,
+--     take H : cons x s ≠ nil,
+--     calc
+--       head x0 (concat (cons x s) t) = head x0 (cons x (concat s t)) : {cons_concat _ _ _}
+--         ... = x : {head_cons _ _ _}
+--         ... = head x0 (cons x s) : {symm ( head_cons x x0 s)})
+
+-- definition tail : list T → list T := list_rec nil (fun x l b, l)
+
+-- theorem tail_nil : tail (@nil T) = nil := refl _
+
+-- theorem tail_cons (x : T) (l : list T) : tail (cons x l) = l := refl _
+
+-- theorem cons_head_tail (x0 : T) (l : list T) : l ≠ nil → (head x0 l) :: (tail l) = l :=
+-- list_cases_on l
+--   (assume H : nil ≠ nil, absurd (refl _) H)
+--   (take x l, assume H : cons x l ≠ nil, refl _)
+
+
+-- -- List membership
+-- -- ---------------
+
+-- definition mem (x : T) : list T → Prop := list_rec false (fun y l H, x = y ∨ H)
+
+-- infix `∈` := mem
+
+-- -- TODO: constructively, equality is stronger. Use that?
+-- theorem mem_nil (x : T) : x ∈ nil ↔ false := iff_refl _
+
+-- theorem mem_cons (x : T) (y : T) (l : list T) : mem x (cons y l) ↔ (x = y ∨ mem x l) := iff_refl _
+
+-- theorem mem_concat_imp_or (x : T) (s t : list T) : x ∈ s ++ t → x ∈ s ∨ x ∈ t :=
+-- list_induction_on s or_inr
+--   (take y s,
+--     assume IH : x ∈ s ++ t → x ∈ s ∨ x ∈ t,
+--     assume H1 : x ∈ (y :: s) ++ t,
+--     have H2 : x = y ∨ x ∈ s ++ t, from H1,
+--     have H3 : x = y ∨ x ∈ s ∨ x ∈ t, from or_imp_or_right H2 IH,
+--     iff_elim_right or_assoc H3)
+
+-- theorem mem_or_imp_concat (x : T) (s t : list T) : x ∈ s ∨ x ∈ t → x ∈ s ++ t :=
+-- list_induction_on s
+--   (take H, or_elim H (false_elim _) (assume H, H))
+--   (take y s,
+--     assume IH : x ∈ s ∨ x ∈ t → x ∈ s ++ t,
+--     assume H : x ∈ y :: s ∨ x ∈ t,
+--       or_elim H
+--         (assume H1,
+--           or_elim H1
+--             (take H2 : x = y, or_inl H2)
+--             (take H2 : x ∈ s, or_inr (IH (or_inl H2))))
+--         (assume H1 : x ∈ t, or_inr (IH (or_inr H1))))
+
+-- theorem mem_concat (x : T) (s t : list T) : x ∈ s ++ t ↔ x ∈ s ∨ x ∈ t
+-- := iff_intro (mem_concat_imp_or _ _ _) (mem_or_imp_concat _ _ _)
+
+-- theorem mem_split (x : T) (l : list T) : x ∈ l → ∃s t : list T, l = s ++ (x :: t) :=
+-- list_induction_on l
+--   (take H : x ∈ nil, false_elim _ (iff_elim_left (mem_nil x) H))
+--   (take y l,
+--     assume IH : x ∈ l → ∃s t : list T, l = s ++ (x :: t),
+--     assume H : x ∈ y :: l,
+--     or_elim H
+--       (assume H1 : x = y,
+--         exists_intro nil
+--           (exists_intro l (subst H1 (refl _))))
+--       (assume H1 : x ∈ l,
+--         obtain s (H2 : ∃t : list T, l = s ++ (x :: t)), from IH H1,
+--         obtain t (H3 : l = s ++ (x :: t)), from H2,
+--         have H4 : y :: l = (y :: s) ++ (x :: t),
+--           from subst H3 (refl (y :: l)),
+--         exists_intro _ (exists_intro _ H4)))
+
+-- -- Find
+-- -- ----
+
+-- -- to do this: need decidability of = for nat
+-- -- definition find (x : T) : list T → nat
+-- -- := list_rec 0 (fun y l b, if x = y then 0 else succ b)
+
+-- -- theorem find_nil (f : T) : find f nil = 0
+-- -- :=refl _
+
+-- -- theorem find_cons (x y : T) (l : list T) : find x (cons y l) =
+-- --     if x = y then 0 else succ (find x l)
+-- -- := refl _
+
+-- -- theorem not_mem_find (l : list T) (x : T) : ¬ mem x l → find x l = length l
+-- -- :=
+-- --   @list_induction_on T (λl, ¬ mem x l → find x l = length l) l
+-- -- --  list_induction_on l
+-- --     (assume P1 : ¬ mem x nil,
+-- --       show find x nil = length nil, from
+-- --         calc
+-- --           find x nil = 0 : find_nil _
+-- --             ... = length nil : by simp)
+-- --      (take y l,
+-- --        assume IH : ¬ (mem x l) → find x l = length l,
+-- --        assume P1 : ¬ (mem x (cons y l)),
+-- --        have P2 : ¬ (mem x l ∨ (y = x)), from subst P1 (mem_cons _ _ _),
+-- --        have P3 : ¬ (mem x l) ∧ (y ≠ x),from subst P2 (not_or _ _),
+-- --        have P4 : x ≠ y, from ne_symm (and_elim_right P3),
+-- --        calc
+-- --           find x (cons y l) = succ (find x l) :
+-- --               trans (find_cons _ _ _) (not_imp_if_eq P4 _ _)
+-- --             ... = succ (length l) : {IH (and_elim_left P3)}
+-- --             ... = length (cons y l) : symm (length_cons _ _))
+
+-- -- nth element
+-- -- -----------
+
+-- definition nth (x0 : T) (l : list T) (n : ℕ) : T :=
+-- nat_rec (λl, head x0 l) (λm f l, f (tail l)) n l
+
+-- theorem nth_zero (x0 : T) (l : list T) : nth x0 l 0 = head x0 l := refl _
+
+-- theorem nth_succ (x0 : T) (l : list T) (n : ℕ) : nth x0 l (succ n) = nth x0 (tail l) n := refl _
+
+end
+
+end vec

--- a/library/data/vector.lean
+++ b/library/data/vector.lean
@@ -1,12 +1,12 @@
 import data.nat.basic data.empty
 
-open nat eq_ops num
-
-namespace vec
+open nat eq_ops
 
 inductive vec (T : Type) : ℕ → Type :=
 nil {} : vec T 0,
 cons : T → ∀{n}, vec T n → vec T (succ n)
+
+namespace vec
 
 infix `::` := cons --at what level?
 
@@ -18,7 +18,7 @@ notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
 
 theorem rec_on {C : ∀ (n : ℕ), vec T n → Type} {n : ℕ} (v : vec T n) (Hnil : C 0 nil)
   (Hcons : ∀(x : T) {n : ℕ} (w : vec T n), C n w → C (succ n) (cons x w)) : C n v :=
-vec_rec Hnil Hcons v
+vec.rec Hnil Hcons v
 
 theorem induction_on {C : ∀ (n : ℕ), vec T n → Prop} {n : ℕ} (v : vec T n) (Hnil : C 0 nil)
   (Hcons : ∀(x : T) {n : ℕ} (w : vec T n), C n w → C (succ n) (cons x w)) : C n v :=
@@ -30,12 +30,12 @@ rec_on v Hnil (take x n v IH, Hcons x v)
 
 theorem case_zero_lem [private] {C : vec T 0 → Type} {n : ℕ} (v : vec T n) (Hnil : C nil) :
   ∀ H : n = 0, C (cast (congr_arg (vec T) H) v) :=
-rec_on v (take H : 0 = 0, (eq_rec Hnil (cast_eq _ nil⁻¹)))
+rec_on v (take H : 0 = 0, (eq.rec Hnil (cast_eq _ nil⁻¹)))
  (take (x : T) (n : ℕ) (w : vec T n) IH (H : succ n = 0),
-    false_rec_type _ (absurd H succ_ne_zero))
+    false.rec_type _ (absurd H succ_ne_zero))
 
 theorem case_zero {C : vec T 0 → Type} (v : vec T 0) (Hnil : C nil) : C v :=
-eq_rec (case_zero_lem v Hnil (refl 0)) (cast_eq _ v)
+eq.rec (case_zero_lem v Hnil (eq.refl 0)) (cast_eq _ v)
 
 
 -- Definition rectS {A} (P:forall {n}, t A (S n) -> Type)
@@ -61,7 +61,7 @@ eq_rec (case_zero_lem v Hnil (refl 0)) (cast_eq _ v)
 theorem rec_nonempty_lem [private] {C : Π{n}, vec T (succ n) → Type} {n : ℕ} (v : vec T n)
     (Hone : Πa, C [a]) (Hcons : Πa {n} (v : vec T (succ n)), C v → C (a :: v))
     : ∀{m} (H : n = succ m), C (cast (congr_arg (vec T) H) v) :=
-case_on v (take m (H : 0 = succ m), false_rec_type _ (absurd (H⁻¹) succ_ne_zero))
+case_on v (take m (H : 0 = succ m), false.rec_type _ (absurd (H⁻¹) succ_ne_zero))
   (take x n v m H,
     have H2 : C (x::v), from
       sorry,
@@ -105,7 +105,7 @@ abbreviation cast_subst {A : Type} {P : A → Type} {a a' : A} (H : a = a') (B :
 cast (congr_arg P H) B
 
 definition concat {n m : ℕ} (v : vec T n) (w : vec T m) : vec T (n + m) :=
-vec_rec (cast_subst (add_zero_left⁻¹) w) (λx n w' u, cast_subst (add_succ_left⁻¹) (x::u)) v
+vec.rec (cast_subst (add_zero_left⁻¹) w) (λx n w' u, cast_subst (add_succ_left⁻¹) (x::u)) v
 
 infixl `++` : 65 := concat
 

--- a/library/data/vector.lean
+++ b/library/data/vector.lean
@@ -1,5 +1,6 @@
 import data.nat.basic data.empty
-using nat eq_ops num
+
+open nat eq_ops num
 
 namespace vec
 
@@ -342,6 +343,6 @@ theorem length_nil : length (@nil T) = 0 := rfl
 
 -- theorem nth_succ (x0 : T) (l : list T) (n : ℕ) : nth x0 l (succ n) = nth x0 (tail l) n := refl _
 
-end
+end sc_vec
 
 end vec


### PR DESCRIPTION
Here are my current versions of category.lean and vector.lean. There isn't much in either, but it's a start. It compiles with the current version, so it's updated to use "open" and "." (instead of "include" and "_"). It does use some superfluous sorry's and check's
