### PR TITLE
Ported Pointed.v, Funext_Varieties.v and a good part of UnivalenceImpliesFunext.v

### DIFF
--- a/library/hott/funext_from_ua.lean
+++ b/library/hott/funext_from_ua.lean
@@ -2,13 +2,20 @@
 -- Released under Apache 2.0 license as described in the file LICENSE.
 -- Author: Jakob von Raumer
 -- Ported from Coq HoTT
-import hott.axioms.ua hott.equiv hott.equiv_precomp hott.funext_varieties
+import hott.equiv hott.equiv_precomp hott.funext_varieties
 import data.prod data.sigma data.unit
 
 open path function prod sigma truncation Equiv unit
 
+definition isequiv_path {A B : Type} (H : A ≈ B) :=
+  (@IsEquiv.transport Type (λX, X) A B H)
+
+
+definition equiv_path {A B : Type} (H : A ≈ B) : A ≃ B :=
+  Equiv.mk _ (isequiv_path H)
+
 -- First, define an axiom free variant of Univalence
-definition ua_type := Π (A B : Type), IsEquiv (equiv_path A B)
+definition ua_type := Π (A B : Type), IsEquiv (@equiv_path A B)
 
 context
   parameters {ua : ua_type}
@@ -83,7 +90,7 @@ context
             from (λ x, @equiv_contr_unit (P x) (allcontr x)),
           have psim : Πx, P x ≈ U x,
             from (λ x, @IsEquiv.inv _ _
-              (equiv_path.{1} (P x) (U x)) (ua1 (P x) (U x)) (pequiv x)),
+              (@equiv_path.{1} (P x) (U x)) (ua1 (P x) (U x)) (pequiv x)),
           have p : P ≈ U,
             from ua_implies_funext_nondep psim,
           have tU' : is_contr (A → unit),

--- a/library/hott/funext_from_ua.lean
+++ b/library/hott/funext_from_ua.lean
@@ -1,0 +1,81 @@
+-- Copyright (c) 2014 Jakob von Raumer. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Author: Jakob von Raumer
+-- Ported from Coq HoTT
+import hott.axioms.ua hott.equiv hott.equiv_precomp
+import data.prod data.sigma
+
+open path function prod sigma
+
+-- First, define an axiom free variant of Univalence
+definition ua_type := Π (A B : Type), IsEquiv (equiv_path A B)
+
+context
+  parameters {ua : ua_type}
+
+  -- TODO base this theorem on UA instead of FunExt.
+  -- IsEquiv.postcompose relies on FunExt!
+  protected theorem ua_isequiv_postcompose {A B C : Type} {w : A → B} {H0 : IsEquiv w}
+      : IsEquiv (@compose C A B w) :=
+    !IsEquiv.postcompose
+
+  -- We are ready to prove functional extensionality,
+  -- starting with the naive non-dependent version.
+  protected definition diagonal [reducible] (B : Type) : Type
+    := Σ xy : B × B, pr₁ xy ≈ pr₂ xy
+
+  protected definition isequiv_src_compose {A B C : Type}
+      : @IsEquiv (A → diagonal B)
+                 (A → B)
+                 (compose (pr₁ ∘ dpr1))
+    := @ua_isequiv_postcompose _ _ _ (pr₁ ∘ dpr1)
+        (IsEquiv.adjointify (pr₁ ∘ dpr1)
+          (λ x, dpair (x , x) idp) (λx, idp)
+          (λ x, sigma.rec_on x
+            (λ xy, prod.rec_on xy
+              (λ b c p, path.rec_on p idp))))
+
+  protected definition isequiv_tgt_compose {A B C : Type}
+      : @IsEquiv (A → diagonal B)
+                 (A → B)
+                 (compose (pr₂ ∘ dpr1))
+    := @ua_isequiv_postcompose _ _ _ (pr2 ∘ dpr1)
+        (IsEquiv.adjointify (pr2 ∘ dpr1)
+          (λ x, dpair (x , x) idp) (λx, idp)
+          (λ x, sigma.rec_on x
+            (λ xy, prod.rec_on xy
+              (λ b c p, path.rec_on p idp))))
+
+  theorem univalence_implies_funext_nondep (A B : Type)
+      : Π (f g : A → B), f ∼ g → f ≈ g
+    := (λ (f g : A → B) (p : f ∼ g),
+          let d := λ (x : A), dpair (f x , f x) idp in
+          let e := λ (x : A), dpair (f x , g x) (p x) in
+          let precomp1 :=  compose (pr₁ ∘ dpr1) in
+          have equiv1 [visible] : IsEquiv precomp1,
+            from @isequiv_src_compose A B (diagonal B),
+          have equiv2 [visible] : Π x y, IsEquiv (ap precomp1),
+            from IsEquiv.ap_closed precomp1,
+          have H' : Π (x y : A → diagonal B),
+              pr₁ ∘ dpr1 ∘ x ≈ pr₁ ∘ dpr1 ∘ y → x ≈ y,
+            from (λ x y, IsEquiv.inv (ap precomp1)),
+          have eq2 : pr₁ ∘ dpr1 ∘ d ≈ pr₁ ∘ dpr1 ∘ e,
+            from idp,
+          have eq0 : d ≈ e,
+            from H' d e eq2,
+          have eq1 : (pr₂ ∘ dpr1) ∘ d ≈ (pr₂ ∘ dpr1) ∘ e,
+            from ap _ eq0,
+          eq1
+       )
+
+end
+
+
+
+
+
+
+-- In the following we will proof function extensionality using the univalence axiom
+definition funext_from_ua {A : Type} {P : A → Type} (f g : Πx, P x)
+    : IsEquiv (@apD10 A P f g) :=
+  sorry

--- a/library/hott/funext_varieties.lean
+++ b/library/hott/funext_varieties.lean
@@ -1,0 +1,83 @@
+-- Copyright (c) 2014 Jakob von Raumer. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Jakob von Raumer
+-- Ported from Coq HoTT
+import hott.path hott.trunc hott.equiv
+
+open path truncation sigma
+
+/- In hott.axioms.funext, we defined function extensionality to be the assertion
+   that the map apD10 is an equivalence.   We now prove that this follows
+   from a couple of weaker-looking forms of function extensionality.  We do
+   require eta conversion, which Coq 8.4+ has judgmentally.
+
+   This proof is originally due to Voevodsky; it has since been simplified
+   by Peter Lumsdaine and Michael Shulman. -/
+
+-- Naive funext is the simple assertion that pointwise equal functions are equal.
+-- TODO think about universe levels
+definition naive_funext :=
+  Π (A : Type) (P : A → Type) (f g : Πx, P x), (f ∼ g) → f ≈ g
+
+-- Weak funext says that a product of contractible types is contractible.
+definition weak_funext :=
+  Π (A : Type₁) (P : A → Type₁), (Πx, is_contr (P x)) → is_contr (Πx, P x)
+
+-- We define a variant of [Funext] which does not invoke an axiom.
+definition funext_type :=
+  Π (A : Type₁) (P : A → Type₁) (f g : Πx, P x), IsEquiv (@apD10 A P f g)
+
+-- The obvious implications are Funext -> NaiveFunext -> WeakFunext
+-- TODO: Get class inference to work locally
+definition funext_implies_naive_funext : funext_type → naive_funext :=
+  (λ Fe A P f g h,
+    have Fefg: IsEquiv (@apD10 A P f g), from Fe A P f g,
+    have eq1 : _, from (@IsEquiv.inv _ _ (@apD10 A P f g) Fefg h),
+    eq1
+  )
+
+/-definition naive_funext_implies_weak_funext : naive_funext → weak_funext :=
+  (λ nf A P Pc,
+    let c := λx, @center (P x) (Pc x) in
+    let p : Π (f : Πx, P x) (x : A), (c x) ≈ (f x) := sorry in
+    is_contr.mk c (λ f, nf A P c f (λx, p f x))
+  )-/
+
+
+/- The less obvious direction is that WeakFunext implies Funext
+  (and hence all three are logically equivalent).  The point is that under weak
+  funext, the space of "pointwise homotopies" has the same universal property as
+  the space of paths. -/
+
+context
+  parameters (wf : weak_funext) {A : Type₁} {B : A → Type₁} (f : Πx, B x)
+
+  protected definition idhtpy : f ∼ f := (λx, idp)
+
+  definition contr_basedhtpy : is_contr (Σ (g : Πx, B x), f ∼ g) :=
+    is_contr.mk (dpair f idhtpy)
+      (λ dp, sigma.rec_on dp
+        (λ (g : Πx, B x) (h : f ∼ g),
+          let r := λ (k : Πx, Σ (y : B x), f x ≈ y),
+            @dpair _ (λg, f ∼ g)
+              (λx, dpr1 (k x)) (λx, dpr2 (k x)) in
+          let s := λ g h x, @dpair _ (λy, f x ≈ y) (g x) (h x) in
+          have t1 : Πx, is_contr (Σ y, f x ≈ y),
+            from (λx, !contr_basedpaths),
+          have t2 : is_contr (Πx, Σ (y : B x), f x ≈ y),
+            from wf _ _ t1,
+          have t3 : (λ x, @dpair _ (λy, f x ≈ y) (f x) idp) ≈ s g h,
+            from @path_contr (Πx, Σ (y : B x), f x ≈ y) t2 _ _,
+          have t4 : r (λ x, dpair (f x) idp) ≈ r (s g h),
+            from ap r t3,
+          have endt : dpair f idhtpy ≈ dpair g h,
+            from t4,
+          endt
+        )
+      )
+
+  parameters (Q : Π g (h : f ∼ g), Type) (d : Q f idhtpy)
+
+
+
+end

--- a/library/hott/funext_varieties.lean
+++ b/library/hott/funext_varieties.lean
@@ -17,15 +17,15 @@ open path truncation sigma function
 -- Naive funext is the simple assertion that pointwise equal functions are equal.
 -- TODO think about universe levels
 definition naive_funext :=
-  Π (A : Type) (P : A → Type) (f g : Πx, P x), (f ∼ g) → f ≈ g
+  Π {A : Type} {P : A → Type} (f g : Πx, P x), (f ∼ g) → f ≈ g
 
 -- Weak funext says that a product of contractible types is contractible.
 definition weak_funext :=
-  Π (A : Type₁) (P : A → Type₁), (Πx, is_contr (P x)) → is_contr (Πx, P x)
+  Π {A : Type₁} (P : A → Type₁) [H: Πx, is_contr (P x)], is_contr (Πx, P x)
 
 -- We define a variant of [Funext] which does not invoke an axiom.
 definition funext_type :=
-  Π (A : Type₁) (P : A → Type₁) (f g : Πx, P x), IsEquiv (@apD10 A P f g)
+  Π {A : Type₁} {P : A → Type₁} (f g : Πx, P x), IsEquiv (@apD10 A P f g)
 
 -- The obvious implications are Funext -> NaiveFunext -> WeakFunext
 -- TODO: Get class inference to work locally
@@ -37,13 +37,13 @@ definition funext_implies_naive_funext : funext_type → naive_funext :=
   )
 
 definition naive_funext_implies_weak_funext : naive_funext → weak_funext :=
-  (λ nf A P Pc,
-    let c := λx, @center (P x) (Pc x) in
+  (λ nf A P (Pc : Πx, is_contr (P x)),
+    let c := λx, center (P x) in
     is_contr.mk c (λ f,
-      have eq' : (λx, @center (P x) (Pc x)) ∼ f,
-        from (λx, @contr (P x) (Pc x) (f x)),
-      have eq : (λx, @center (P x) (Pc x)) ≈ f,
-        from nf A P (λx, @center (P x) (Pc x)) f eq',
+      have eq' : (λx, center (P x)) ∼ f,
+        from (λx, contr (f x)),
+      have eq : (λx, center (P x)) ≈ f,
+        from nf A P (λx, center (P x)) f eq',
       eq
     )
   )
@@ -62,17 +62,17 @@ context
   definition contr_basedhtpy [instance] : is_contr (Σ (g : Πx, B x), f ∼ g) :=
     is_contr.mk (dpair f idhtpy)
       (λ dp, sigma.rec_on dp
-        (λ (g : Πx, B x) (h : f ∼ g),
-          let r := λ (k : Πx, Σ (y : B x), f x ≈ y),
+        (λ (g : Π x, B x) (h : f ∼ g),
+          let r := λ (k : Π x, Σ y, f x ≈ y),
             @dpair _ (λg, f ∼ g)
               (λx, dpr1 (k x)) (λx, dpr2 (k x)) in
           let s := λ g h x, @dpair _ (λy, f x ≈ y) (g x) (h x) in
-          have t1 [visible] : Πx, is_contr (Σ y, f x ≈ y),
+          have t1 : Πx, is_contr (Σ y, f x ≈ y),
             from (λx, !contr_basedpaths),
-          have t2 : is_contr (Πx, Σ (y : B x), f x ≈ y),
-            from wf _ _ t1,
-          have t3 : (λ x, @dpair _ (λy, f x ≈ y) (f x) idp) ≈ s g h,
-            from @path_contr (Πx, Σ (y : B x), f x ≈ y) t2 _ _,
+          have t2 : is_contr (Πx, Σ y, f x ≈ y),
+            from !wf,
+          have t3 : (λ x, @dpair _ (λ y, f x ≈ y) (f x) idp) ≈ s g h,
+            from @path_contr (Π x, Σ y, f x ≈ y) t2 _ _,
           have t4 : r (λ x, dpair (f x) idp) ≈ r (s g h),
             from ap r t3,
           have endt : dpair f idhtpy ≈ dpair g h,

--- a/library/hott/pointed.lean
+++ b/library/hott/pointed.lean
@@ -1,0 +1,39 @@
+-- Copyright (c) 2014 Jakob von Raumer. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Author: Jakob von Raumer
+-- Ported from Coq HoTT
+import hott.path hott.trunc data.sigma data.prod
+
+open path prod
+
+inductive is_pointed [class] (A : Type) :=
+  pointed_mk : Π(a : A), is_pointed A
+
+namespace is_pointed
+  variables {A B : Type} (f : A → B)
+
+  definition point (A : Type) [H : is_pointed A] : A :=
+    is_pointed.rec (λinv, inv) H
+
+  -- Any contractible type is pointed
+  protected definition contr [instance] (H : Contr A) : is_pointed A :=
+    pointed_mk (center H)
+
+  -- A pi type with a pointed target is pointed
+  protected definition pi [instance] {P : A → Type} [H : Πx, is_pointed (P x)]
+      : is_pointed (Πx, P x) :=
+    pointed_mk (λx, point (P x))
+
+  -- A sigma type of pointed components is pointed
+  protected definition sigma [instance] {P : A → Type} [G : is_pointed A]
+      [H : is_pointed (P (point A))] : is_pointed (Σx, P x) :=
+    pointed_mk (sigma.dpair (point A) (point (P (point A))))
+
+  protected definition prod [H1 : is_pointed A] [H2 : is_pointed B]
+      : is_pointed (A × B) :=
+    pointed_mk (prod.mk (point A) (point B))
+
+  protected definition loop_space (a : A) : is_pointed (a ≈ a) :=
+    pointed_mk idp
+
+end is_pointed

--- a/library/hott/pointed.lean
+++ b/library/hott/pointed.lean
@@ -4,20 +4,20 @@
 -- Ported from Coq HoTT
 import hott.path hott.trunc data.sigma data.prod
 
-open path prod
+open path prod truncation
 
 inductive is_pointed [class] (A : Type) :=
   pointed_mk : Π(a : A), is_pointed A
 
 namespace is_pointed
-  variables {A B : Type} (f : A → B)
+  variables {A B : Type.{1}} (f : A → B)
 
   definition point (A : Type) [H : is_pointed A] : A :=
     is_pointed.rec (λinv, inv) H
 
   -- Any contractible type is pointed
-  protected definition contr [instance] (H : Contr A) : is_pointed A :=
-    pointed_mk (center H)
+  protected definition contr [instance] [H : is_contr A] : is_pointed A :=
+    pointed_mk (center A)
 
   -- A pi type with a pointed target is pointed
   protected definition pi [instance] {P : A → Type} [H : Πx, is_pointed (P x)]

--- a/library/hott/trunc.lean
+++ b/library/hott/trunc.lean
@@ -238,6 +238,16 @@ namespace truncation
   Equiv.mk f (isequiv_iff_hprop f g)
   end
 
+  /- interaction with the Unit type -/
+
+  -- A contractible type is equivalent to [Unit]. *)
+  definition equiv_contr_unit [H : is_contr A] : A ≃ unit :=
+    Equiv.mk (λ (x : A), ⋆)
+      (IsEquiv.mk (λ (u : unit), center A)
+        (λ (u : unit), unit.rec_on u idp)
+        (λ (x : A), contr x)
+        (λ (x : A), (!ap_const)⁻¹))
+
   -- TODO: port "Truncated morphisms"
 
 end truncation


### PR DESCRIPTION
UnivalenceImpliesFunext.v still lacks a proof of postcomposition with an equivlance being an equivalence that does not rely on function extensionality. This proof is weird and I will take a look at it tomorrow...
