### PR TITLE
refactor(library/data/int/basic): make the integers an instance of ring

### DIFF
--- a/library/data/int/basic.lean
+++ b/library/data/int/basic.lean
@@ -85,24 +85,12 @@ definition mul (a b : ℤ) : ℤ :=
         (take n, neg_of_nat (succ m * n))                -- b = of_nat n
         (take n, of_nat (succ m * succ n)))              -- b = neg_succ_of_nat n
 
-definition sub (a b : ℤ) : ℤ := add a (neg b)
-
-definition nonneg (a : ℤ) : Prop := cases_on a (take n, true) (take n, false)
-
-definition le (a b : ℤ) : Prop := nonneg (sub b a)
-
-definition lt (a b : ℤ) : Prop := le (add a 1) b
-
 /- notation -/
 
 notation `-[` n `+1]` := int.neg_succ_of_nat n    -- for pretty-printing output
 prefix - := int.neg
 infix +  := int.add
 infix *  := int.mul
-infix -  := int.sub
-infix <= := int.le
-infix ≤  := int.le
-infix <  := int.lt
 
 /- some basic functions and properties -/
 
@@ -563,7 +551,7 @@ zero_ne_one mul.comm
 Instantiate ring theorems to int
 -/
 
-section port_algebra
+context port_algebra
   open algebra    -- TODO: can we "open" algebra only for the duration of this section?
   instance comm_ring
 
@@ -608,13 +596,16 @@ section port_algebra
     @algebra.add_eq_iff_eq_neg_add _ _
   theorem add_eq_iff_eq_add_neg : ∀a b c : ℤ, a + b = c ↔ a = c + -b :=
     @algebra.add_eq_iff_eq_add_neg _ _
+
+  definition sub (a b : ℤ) : ℤ := algebra.sub a b
+  infix - := int.sub
+
   theorem sub_self : ∀a : ℤ, a - a = 0 := algebra.sub_self
   theorem sub_add_cancel : ∀a b : ℤ, a - b + b = a := algebra.sub_add_cancel
   theorem add_sub_cancel : ∀a b : ℤ, a + b - b = a := algebra.add_sub_cancel
   theorem eq_of_sub_eq_zero : ∀{a b : ℤ}, a - b = 0 → a = b := @algebra.eq_of_sub_eq_zero _ _
   theorem eq_iff_sub_eq_zero : ∀a b : ℤ, a = b ↔ a - b = 0 := algebra.eq_iff_sub_eq_zero
--- TODO: is there a bug here? see below
--- theorem zero_sub_eq : ∀a : ℤ, 0 - a = -a := algebra.zero_sub_eq
+  theorem zero_sub_eq : ∀a : ℤ, 0 - a = -a := algebra.zero_sub_eq
   theorem sub_zero_eq : ∀a : ℤ, a - 0 = a := algebra.sub_zero_eq
   theorem sub_neg_eq_add : ∀a b : ℤ, a - (-b) = a + b := algebra.sub_neg_eq_add
   theorem neg_sub_eq : ∀a b : ℤ, -(a - b) = b - a := algebra.neg_sub_eq
@@ -650,48 +641,16 @@ section port_algebra
   theorem mul_self_sub_one_eq : ∀a : ℤ, a * a - 1 = (a + 1) * (a - 1) :=
     algebra.mul_self_sub_one_eq
 
-/-
--- TODO: Something strange is going on this this theorem.
-
-set_option pp.implicit true
-set_option pp.coercions true
-set_option pp.notation false
-
-theorem zero_sub_eq : ∀a : ℤ, 0 - a = -a := algebra.zero_sub_eq
-
--- Lean reports a type mismatch, but evaluating both sides gives exactly the same result.
-
-eval
-   ∀ (a : int),
-    @eq int
-      (@algebra.sub int
-         (@add_comm_group.to_add_group int
-            (@ring.to_add_comm_group int (@comm_ring.to_ring int comm_ring)))
-         (@has_zero.zero int
-            (@add_monoid.to_has_zero int
-               (@add_group.to_add_monoid int
-                  (@add_comm_group.to_add_group int
-                     (@ring.to_add_comm_group int (@comm_ring.to_ring int comm_ring))))))
-         a)
-      (@has_neg.neg int
-         (@add_group.to_has_neg int
-            (@add_comm_group.to_add_group int
-               (@ring.to_add_comm_group int (@comm_ring.to_ring int comm_ring))))
-         a)
-
-eval
-   ∀ (a : int),
-    @eq int
-      (sub
-         (@has_zero.zero int
-            (@zero_ne_one_class.to_has_zero int
-               (@ring.to_zero_ne_one_class int (@comm_ring.to_ring int comm_ring))))
-         a)
-      (neg a)
--/
-
 end port_algebra
 
+definition nonneg (a : ℤ) : Prop := cases_on a (take n, true) (take n, false)
+definition le (a b : ℤ) : Prop := nonneg (sub b a)
+definition lt (a b : ℤ) : Prop := le (add a 1) b
+
+infix - := int.sub
+infix <= := int.le
+infix ≤  := int.le
+infix <  := int.lt
 
 /-
   Other stuff.


### PR DESCRIPTION
I made the integers and instance of the class comm_ring, and then "ported" facts about rings to the integers.

Some notes:

As proof of concept, it went pretty well. It is nice that basic facts about the integers are now instances of the generic algebraic theorems, with the same names.

There is still a lot more to do. I still need to do the same for the ordering on int, and also make int an integral domain with dvd and abs, and ordered_ring, etc. And I have to do the similar thing for nat.

As predicted, porting the list of theorems by hand is tedious, but workable. It will be nice to have automation for this later.

One of the theorems uncovered a possible bug. At least, I can't understand why one theorem (and only one from the list I ported!) fails to type check. Lean reports a Type mismatch, but evaluating both sides yields exactly the same term. Search on "TODO" in int/basic.lean.

Question: when porting theorems, I used "open algebra". Is there any way to "limit" the open to a section, or "close" it afterwards? It would be nice if the "open" were limited to the scope of a section. In general, I have noticed that overloading can be a real pain -- error messages, for example, become less helpful. When working with ints, it would be helpful to open nat notation very selectively.

@javra : I am afraid I renamed some theorems in group.lean:

  eq_of_neg_eq_neg -> neg.inj
  neg_zero_eq -> neg_zero
  neg_neg_eq_ -> neg_neg
  eq_of_inv_eq_inv -> inv.inj
  inv_one_eq -> inv_one
  inv_inv_eq -> inv_inv

I am afraid there will be a lot more renaming and housecleaning to come. In particular, I have to revise nat to match our naming conventions.

By the way: the naming conventions are working really well. Autocompletion is great.
